### PR TITLE
Make routes forward compatible

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -1,6 +1,4 @@
 <?php
-use Cake\Routing\Router;
-
 /** @var \Cake\Routing\RouteBuilder $routes */
 $routes->plugin('Burzum/FileStorage', function($routes) {
     $routes->fallbacks();

--- a/config/routes.php
+++ b/config/routes.php
@@ -3,3 +3,4 @@
 $routes->plugin('Burzum/FileStorage', function($routes) {
     $routes->fallbacks();
 });
+

--- a/config/routes.php
+++ b/config/routes.php
@@ -1,6 +1,7 @@
 <?php
 use Cake\Routing\Router;
 
+/** @var \Cake\Routing\RouteBuilder $routes */
 $routes->plugin('Burzum/FileStorage', function($routes) {
     $routes->fallbacks();
 });

--- a/config/routes.php
+++ b/config/routes.php
@@ -1,6 +1,6 @@
 <?php
 use Cake\Routing\Router;
 
-Router::plugin('Burzum/FileStorage', function($routes) {
-	$routes->fallbacks();
+$routes->plugin('Burzum/FileStorage', function($routes) {
+    $routes->fallbacks();
 });


### PR DESCRIPTION
Since the newest release is from the 3.x branch im proposing this here. Using said release (3.1.3) leads to deprecation warnings in CakePHP 4.3. Im aware that newer tags already have CakePHP 4.x conform routes however since this branch requires "cakephp/cakephp": "^4.0", in composer JSON i think this branch should also adhere to the new route structure.