### PR TITLE
Rename Plugin Class to FileStoragePlugin

### DIFF
--- a/src/FileStoragePlugin.php
+++ b/src/FileStoragePlugin.php
@@ -8,6 +8,6 @@ use Cake\Core\BasePlugin;
 /**
  * FileStorage Plugin for CakePHP
  */
-class Plugin extends BasePlugin
+class FileStoragePlugin extends BasePlugin
 {
 }


### PR DESCRIPTION
While updating our CakePHP version we came across this deprecation warning:

> Since 5.3.0: Loading plugins with a plugin class named `Plugin` is deprecated. Rename the class to `FileStoragePlugin` instead.

Renaming the Class & File resolved this deprecation warning.